### PR TITLE
Specify token override using a custom httpx client

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ However, Azure Container Registry has a fixed cost per registry per day.
 
 You can try the [Azure pricing calculator](https://azure.microsoft.com/pricing/calculator/) for the resources:
 
-* Azure AI Service: S0 tier, DeepSeek-RW model. Pricing is based on token count. [Pricing]()
+* Azure AI Service: S0 tier, DeepSeek-RW model. Pricing is based on token count. [Pricing](https://aka.ms/DeepSeekPricing)
 * Azure Container App: Consumption tier with 0.5 CPU, 1GiB memory/storage. Pricing is based on resource allocation, and each month allows for a certain amount of free usage. [Pricing](https://azure.microsoft.com/pricing/details/container-apps/)
 * Azure Container Registry: Basic tier. [Pricing](https://azure.microsoft.com/pricing/details/container-registry/)
 * Log analytics: Pay-as-you-go tier. Costs based on data ingested. [Pricing](https://azure.microsoft.com/pricing/details/monitor/)


### PR DESCRIPTION
## Purpose

There was concern with the previous method that developers may forget to refresh the token before sending a request, so now we pass in a custom httpx client to the OpenAI constructor, and set the authorization header inside that client.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Run locally
* Deploy, wait a few hours, confirm it still works